### PR TITLE
Updates to support 25Live

### DIFF
--- a/uw_r25/__init__.py
+++ b/uw_r25/__init__.py
@@ -12,6 +12,13 @@ def get_resource(url):
     Issue a GET request to R25 with the given url
     and return a response as an etree element.
     """
+
+    instance = R25_DAO().get_service_setting('INSTANCE')
+    if instance is not None:
+        url = "/r25ws/wrd/%s/run/%s" % (instance, url)
+    else:
+        url = "/r25ws/servlet/wrd/run/%s" % url
+
     response = R25_DAO().getURL(url, {"Accept": "text/xml"})
     if response.status != 200:
         raise DataFailureException(url, response.status, response.data)

--- a/uw_r25/dao.py
+++ b/uw_r25/dao.py
@@ -11,3 +11,8 @@ class R25_DAO(DAO):
 
     def service_mock_paths(self):
         return [abspath(os.path.join(dirname(__file__), "resources"))]
+
+    def _custom_headers(self, method, url, headers, body):
+        basic_auth = self.get_service_setting('BASIC_AUTH')
+        if basic_auth is not None:
+            return {"Authorization": "Basic %s" % basic_auth}

--- a/uw_r25/events.py
+++ b/uw_r25/events.py
@@ -8,12 +8,12 @@ except:
 
 
 def get_event_by_id(event_id):
-    url = "/r25ws/servlet/wrd/run/event.xml?event_id=%s" % event_id
+    url = "event.xml?event_id=%s" % event_id
     return events_from_xml(get_resource(url))[0]
 
 
 def get_event_by_alien_id(alien_id):
-    url = "/r25ws/servlet/wrd/run/event.xml?alien_uid=%s" % quote(alien_id)
+    url = "event.xml?alien_uid=%s" % quote(alien_id)
     event = events_from_xml(get_resource(url))
     return event[0] if event else None
 
@@ -24,7 +24,7 @@ def get_events(**kwargs):
     Supported kwargs are listed at
     http://knowledge25.collegenet.com/display/WSW/events.xml
     """
-    url = "/r25ws/servlet/wrd/run/events.xml"
+    url = "events.xml"
     if len(kwargs):
         url += "?%s" % urlencode(kwargs)
 

--- a/uw_r25/reservations.py
+++ b/uw_r25/reservations.py
@@ -8,7 +8,7 @@ except:
 
 
 def get_reservation_by_id(reservation_id):
-    url = "/r25ws/servlet/wrd/run/reservation.xml?rsrv_id=%s" % reservation_id
+    url = "reservation.xml?rsrv_id=%s" % reservation_id
     return reservations_from_xml(get_resource(url))[0]
 
 
@@ -19,7 +19,7 @@ def get_reservations(**kwargs):
     http://knowledge25.collegenet.com/display/WSW/reservations.xml
     """
     kwargs["scope"] = "extended"
-    url = "/r25ws/servlet/wrd/run/reservations.xml"
+    url = "reservations.xml"
     if len(kwargs):
         url += "?%s" % urlencode(kwargs)
 

--- a/uw_r25/reservations.py
+++ b/uw_r25/reservations.py
@@ -68,9 +68,8 @@ def reservations_from_xml(tree):
                                                    namespaces=nsmap)[0].text
             try:
                 anode = cnode.xpath("r25:address", namespaces=nsmap)[0]
-                reservation.contact_email = anode.xpath("r25:email",
-                                                        namespaces=nsmap)
-                [0].text
+                reservation.contact_email = anode.xpath(
+                    "r25:email", namespaces=nsmap)[0].text
             except IndexError:
                 reservation.contact_email = None
 

--- a/uw_r25/spaces.py
+++ b/uw_r25/spaces.py
@@ -7,7 +7,7 @@ except:
 
 
 def get_space_by_id(space_id):
-    url = "/r25ws/servlet/wrd/run/space.xml?space_id=%s" % space_id
+    url = "space.xml?space_id=%s" % space_id
     return spaces_from_xml(get_resource(url))[0]
 
 
@@ -17,7 +17,7 @@ def get_spaces(**kwargs):
     Supported kwargs are listed at
     http://knowledge25.collegenet.com/display/WSW/spaces.xml
     """
-    url = "/r25ws/servlet/wrd/run/spaces.xml"
+    url = "spaces.xml"
     if len(kwargs):
         url += "?%s" % urlencode(kwargs)
 

--- a/uw_r25/tests/test_dao.py
+++ b/uw_r25/tests/test_dao.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+from uw_r25.dao import R25_DAO
+from commonconf import override_settings
+
+
+class R25TestDao(TestCase):
+
+    def test_custom_headers(self):
+        self.assertFalse(R25_DAO()._custom_headers('GET', '/', {}, None))
+        with override_settings(RESTCLIENTS_R25_BASIC_AUTH='b64here'):
+            self.assertEquals(
+                R25_DAO()._custom_headers('GET', '/', {}, None),
+                {'Authorization': 'Basic b64here'}
+            )


### PR DESCRIPTION
I started testing the webservice of 25Live for the upcoming transition, and there are just minor changes needed to support it.
25Live requires authentication. Use basic auth by setting RESTCLIENTS_R25_BASIC_AUTH to base64(username:password). Digest auth and an xml-based challenge/response method are also supported by the server.
The url scheme of 25Live needs the instance to query (i.e. 'washington'), so set that with RESTCLIENTS_R25_INSTANCE. Otherwise, it falls back on the hosted url scheme.